### PR TITLE
new alipay Gateway

### DIFF
--- a/alipay/alipay.py
+++ b/alipay/alipay.py
@@ -36,7 +36,7 @@ def smart_str(s, encoding='utf-8', strings_only=False, errors='strict'):
         return s
 
 # 网关地址
-_GATEWAY = 'https://www.alipay.com/cooperate/gateway.do?'
+_GATEWAY = 'https://mapi.alipay.com/gateway.do?'
 
 
 # 对数组排序并除去数组中的空值和签名参数
@@ -171,7 +171,7 @@ def notify_verify(post):
     params['notify_id'] = post.get('notify_id')
     if settings.ALIPAY_TRANSPORT == 'https':
         params['service'] = 'notify_verify'
-        gateway = 'https://www.alipay.com/cooperate/gateway.do'
+        gateway = 'https://mapi.alipay.com/gateway.do'
     else:
         gateway = 'http://notify.alipay.com/trade/notify_query.do'
     veryfy_result = urlopen(gateway, urlencode(params)).read()


### PR DESCRIPTION
支付宝的网关地址在2013年3月就换了，在此网址（ http://club.alipay.com/simple/?t10696603.html ）可以看到相关信息，此PR只修改了这个GATEWAY。

因为最近的一个项目使用了这里的代码，测试时发现notify_verify有验证失败的情况（事实上，我们的服务器刚开始启动后，验证不会失败。运行两三个小时后，这个GATEWAY才失效，可能是支付宝保留了原来的网关，但不稳定）。
